### PR TITLE
Implement orders API with filtering and pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ venv/
 **__pycache__/
 *.pyc
 app/db.sqlite3
+db.sqlite3
+*.sqlite3

--- a/cinema/serializers.py
+++ b/cinema/serializers.py
@@ -1,6 +1,14 @@
 from rest_framework import serializers
 
-from cinema.models import Genre, Actor, CinemaHall, Movie, MovieSession
+from cinema.models import (
+    Genre,
+    Actor,
+    CinemaHall,
+    Movie,
+    MovieSession,
+    Order,
+    Ticket,
+)
 
 
 class GenreSerializer(serializers.ModelSerializer):
@@ -59,6 +67,7 @@ class MovieSessionListSerializer(MovieSessionSerializer):
     cinema_hall_capacity = serializers.IntegerField(
         source="cinema_hall.capacity", read_only=True
     )
+    tickets_available = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = MovieSession
@@ -68,13 +77,52 @@ class MovieSessionListSerializer(MovieSessionSerializer):
             "movie_title",
             "cinema_hall_name",
             "cinema_hall_capacity",
+            "tickets_available",
         )
+
+
+class TicketSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Ticket
+        fields = ("id", "row", "seat", "movie_session")
+
+
+class TicketSeatsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Ticket
+        fields = ("row", "seat")
 
 
 class MovieSessionDetailSerializer(MovieSessionSerializer):
     movie = MovieListSerializer(many=False, read_only=True)
     cinema_hall = CinemaHallSerializer(many=False, read_only=True)
+    taken_places = TicketSeatsSerializer(
+        source="tickets", many=True, read_only=True
+    )
 
     class Meta:
         model = MovieSession
-        fields = ("id", "show_time", "movie", "cinema_hall")
+        fields = ("id", "show_time", "movie", "cinema_hall", "taken_places")
+
+
+class TicketListSerializer(TicketSerializer):
+    movie_session = MovieSessionListSerializer(read_only=True)
+
+
+class OrderSerializer(serializers.ModelSerializer):
+    tickets = TicketSerializer(many=True, read_only=False, allow_empty=False)
+
+    class Meta:
+        model = Order
+        fields = ("id", "tickets", "created_at")
+
+    def create(self, validated_data):
+        tickets_data = validated_data.pop("tickets")
+        order = Order.objects.create(**validated_data)
+        for ticket_data in tickets_data:
+            Ticket.objects.create(order=order, **ticket_data)
+        return order
+
+
+class OrderListSerializer(OrderSerializer):
+    tickets = TicketListSerializer(many=True, read_only=True)

--- a/cinema/serializers.py
+++ b/cinema/serializers.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from rest_framework import serializers
 
 from cinema.models import (
@@ -117,11 +118,12 @@ class OrderSerializer(serializers.ModelSerializer):
         fields = ("id", "tickets", "created_at")
 
     def create(self, validated_data):
-        tickets_data = validated_data.pop("tickets")
-        order = Order.objects.create(**validated_data)
-        for ticket_data in tickets_data:
-            Ticket.objects.create(order=order, **ticket_data)
-        return order
+        with transaction.atomic():
+            tickets_data = validated_data.pop("tickets")
+            order = Order.objects.create(**validated_data)
+            for ticket_data in tickets_data:
+                Ticket.objects.create(order=order, **ticket_data)
+            return order
 
 
 class OrderListSerializer(OrderSerializer):

--- a/cinema/tests/test_actor_api.py
+++ b/cinema/tests/test_actor_api.py
@@ -1,8 +1,6 @@
 from django.test import TestCase
-
 from rest_framework import status
 from rest_framework.test import APIClient
-
 from cinema.models import Actor
 
 
@@ -15,7 +13,7 @@ class ActorApiTests(TestCase):
     def test_get_actors(self):
         response = self.client.get("/api/cinema/actors/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        actors_full_names = [actor["full_name"] for actor in response.data]
+        actors_full_names = [actor["full_name"] for actor in response.data["results"]]
         self.assertEqual(
             sorted(actors_full_names), ["George Clooney", "Keanu Reeves"]
         )

--- a/cinema/tests/test_cinema_hall_api.py
+++ b/cinema/tests/test_cinema_hall_api.py
@@ -29,10 +29,10 @@ class CinemaHallApiTests(TestCase):
             "capacity": 300,
         }
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[0]["name"], blue_hall["name"])
-        self.assertEqual(response.data[0]["rows"], blue_hall["rows"])
+        self.assertEqual(response.data["results"][0]["name"], blue_hall["name"])
+        self.assertEqual(response.data["results"][0]["rows"], blue_hall["rows"])
         self.assertEqual(
-            response.data[0]["seats_in_row"], blue_hall["seats_in_row"]
+            response.data["results"][0]["seats_in_row"], blue_hall["seats_in_row"]
         )
         vip_hall = {
             "name": "VIP",
@@ -41,10 +41,10 @@ class CinemaHallApiTests(TestCase):
             "capacity": 48,
         }
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[1]["name"], vip_hall["name"])
-        self.assertEqual(response.data[1]["rows"], vip_hall["rows"])
+        self.assertEqual(response.data["results"][1]["name"], vip_hall["name"])
+        self.assertEqual(response.data["results"][1]["rows"], vip_hall["rows"])
         self.assertEqual(
-            response.data[1]["seats_in_row"], vip_hall["seats_in_row"]
+            response.data["results"][1]["seats_in_row"], vip_hall["seats_in_row"]
         )
 
     def test_post_cinema_halls(self):

--- a/cinema/tests/test_genre_api.py
+++ b/cinema/tests/test_genre_api.py
@@ -1,8 +1,6 @@
 from django.test import TestCase
-
 from rest_framework import status
 from rest_framework.test import APIClient
-
 from cinema.models import Genre
 
 
@@ -18,7 +16,7 @@ class GenreApiTests(TestCase):
 
     def test_get_genres(self):
         response = self.client.get("/api/cinema/genres/")
-        genres = [genre["name"] for genre in response.data]
+        genres = [genre["name"] for genre in response.data["results"]]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(sorted(genres), ["Comedy", "Drama"])
 

--- a/cinema/tests/test_movie_api.py
+++ b/cinema/tests/test_movie_api.py
@@ -39,33 +39,33 @@ class MovieApiTests(TestCase):
         print(movies.data)
         self.assertEqual(movies.status_code, status.HTTP_200_OK)
         for field in titanic:
-            self.assertEqual(movies.data[0][field], titanic[field])
+            self.assertEqual(movies.data["results"][0][field], titanic[field])
 
     def test_get_movies_with_genres_filtering(self):
         movies = self.client.get(
             f"/api/cinema/movies/?genres={self.comedy.id}"
         )
-        self.assertEqual(len(movies.data), 1)
+        self.assertEqual(len(movies.data["results"]), 1)
         movies = self.client.get(
             f"/api/cinema/movies/?genres={self.comedy.id},2,3"
         )
-        self.assertEqual(len(movies.data), 1)
+        self.assertEqual(len(movies.data["results"]), 1)
         movies = self.client.get("/api/cinema/movies/?genres=123213")
-        self.assertEqual(len(movies.data), 0)
+        self.assertEqual(len(movies.data["results"]), 0)
 
     def test_get_movies_with_actors_filtering(self):
         movies = self.client.get(
             f"/api/cinema/movies/?actors={self.actress.id}"
         )
-        self.assertEqual(len(movies.data), 1)
+        self.assertEqual(len(movies.data["results"]), 1)
         movies = self.client.get(f"/api/cinema/movies/?actors={123}")
-        self.assertEqual(len(movies.data), 0)
+        self.assertEqual(len(movies.data["results"]), 0)
 
     def test_get_movies_with_title_filtering(self):
         movies = self.client.get(f"/api/cinema/movies/?title=ita")
-        self.assertEqual(len(movies.data), 1)
+        self.assertEqual(len(movies.data["results"]), 1)
         movies = self.client.get(f"/api/cinema/movies/?title=ati")
-        self.assertEqual(len(movies.data), 0)
+        self.assertEqual(len(movies.data["results"]), 0)
 
     def test_post_movies(self):
         movies = self.client.post(

--- a/cinema/tests/test_movie_api.py
+++ b/cinema/tests/test_movie_api.py
@@ -36,7 +36,6 @@ class MovieApiTests(TestCase):
             "genres": ["Drama", "Comedy"],
             "actors": ["Kate Winslet"],
         }
-        print(movies.data)
         self.assertEqual(movies.status_code, status.HTTP_200_OK)
         for field in titanic:
             self.assertEqual(movies.data["results"][0][field], titanic[field])

--- a/cinema/tests/test_movie_session_api.py
+++ b/cinema/tests/test_movie_session_api.py
@@ -5,7 +5,16 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 from rest_framework import status
 
-from cinema.models import Movie, Genre, Actor, MovieSession, CinemaHall, Ticket
+from cinema.models import (
+    Movie,
+    Genre,
+    Actor,
+    MovieSession,
+    CinemaHall,
+    Ticket,
+    Order,
+)
+from user.models import User
 
 
 class MovieSessionApiTests(TestCase):
@@ -127,3 +136,76 @@ class MovieSessionApiTests(TestCase):
         self.assertEqual(response.data["cinema_hall"]["rows"], 10)
         self.assertEqual(response.data["cinema_hall"]["seats_in_row"], 14)
         self.assertEqual(response.data["cinema_hall"]["name"], "White")
+
+    def test_movie_session_list_shows_tickets_available(self):
+        """Test that movie session list includes tickets_available field"""
+        # Create a user and order with tickets
+        user = User.objects.create(username="testuser")
+        order = Order.objects.create(user=user)
+        
+        # Create 3 tickets for the movie session
+        Ticket.objects.create(
+            movie_session=self.movie_session,
+            order=order,
+            row=1,
+            seat=1
+        )
+        Ticket.objects.create(
+            movie_session=self.movie_session,
+            order=order,
+            row=1,
+            seat=2
+        )
+        Ticket.objects.create(
+            movie_session=self.movie_session,
+            order=order,
+            row=1,
+            seat=3
+        )
+        
+        response = self.client.get("/api/cinema/movie_sessions/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("tickets_available", response.data["results"][0])
+        
+        # Cinema hall capacity (10 * 14 = 140) - 3 tickets sold = 137 available
+        expected_available = self.cinema_hall.capacity - 3
+        self.assertEqual(
+            response.data["results"][0]["tickets_available"],
+            expected_available
+        )
+
+    def test_movie_session_detail_shows_taken_places(self):
+        """Test that movie session detail includes taken_places field"""
+        # Create a user and order with tickets
+        user = User.objects.create(username="testuser")
+        order = Order.objects.create(user=user)
+        
+        # Create tickets with specific seats
+        Ticket.objects.create(
+            movie_session=self.movie_session,
+            order=order,
+            row=5,
+            seat=7
+        )
+        Ticket.objects.create(
+            movie_session=self.movie_session,
+            order=order,
+            row=3,
+            seat=9
+        )
+        
+        response = self.client.get(
+            f"/api/cinema/movie_sessions/{self.movie_session.id}/"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("taken_places", response.data)
+        
+        taken_places = response.data["taken_places"]
+        self.assertEqual(len(taken_places), 2)
+        
+        # Check that taken places include our tickets
+        seats = [(place["row"], place["seat"]) for place in taken_places]
+        self.assertIn((5, 7), seats)
+        self.assertIn((3, 9), seats)

--- a/cinema/tests/test_movie_session_api.py
+++ b/cinema/tests/test_movie_session_api.py
@@ -52,7 +52,7 @@ class MovieSessionApiTests(TestCase):
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
         for field in movie_session:
             self.assertEqual(
-                movie_sessions.data[0][field], movie_session[field]
+                movie_sessions.data["results"][0][field], movie_session[field]
             )
 
     def test_get_movie_sessions_filtered_by_date(self):
@@ -60,45 +60,45 @@ class MovieSessionApiTests(TestCase):
             "/api/cinema/movie_sessions/?date=2022-09-02"
         )
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(movie_sessions.data), 1)
+        self.assertEqual(len(movie_sessions.data["results"]), 1)
 
         movie_sessions = self.client.get(
             "/api/cinema/movie_sessions/?date=2022-09-01"
         )
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(movie_sessions.data), 0)
+        self.assertEqual(len(movie_sessions.data["results"]), 0)
 
     def test_get_movie_sessions_filtered_by_movie(self):
         movie_sessions = self.client.get(
             f"/api/cinema/movie_sessions/?movie={self.movie.id}"
         )
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(movie_sessions.data), 1)
+        self.assertEqual(len(movie_sessions.data["results"]), 1)
 
         movie_sessions = self.client.get(
             "/api/cinema/movie_sessions/?movie=1234"
         )
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(movie_sessions.data), 0)
+        self.assertEqual(len(movie_sessions.data["results"]), 0)
 
     def test_get_movie_sessions_filtered_by_movie_and_data(self):
         movie_sessions = self.client.get(
             f"/api/cinema/movie_sessions/?movie={self.movie.id}&date=2022-09-2"
         )
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(movie_sessions.data), 1)
+        self.assertEqual(len(movie_sessions.data["results"]), 1)
 
         movie_sessions = self.client.get(
             "/api/cinema/movie_sessions/?movie=1234&date=2022-09-2"
         )
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(movie_sessions.data), 0)
+        self.assertEqual(len(movie_sessions.data["results"]), 0)
 
         movie_sessions = self.client.get(
             f"/api/cinema/movie_sessions/?movie={self.movie.id}&date=2022-09-3"
         )
         self.assertEqual(movie_sessions.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(movie_sessions.data), 0)
+        self.assertEqual(len(movie_sessions.data["results"]), 0)
 
     def test_post_movie_session(self):
         movies = self.client.post(

--- a/cinema/tests/test_order_api.py
+++ b/cinema/tests/test_order_api.py
@@ -1,10 +1,7 @@
 from datetime import datetime
-
 from django.test import TestCase
-
 from rest_framework.test import APIClient
 from rest_framework import status
-
 from cinema.models import (
     Movie,
     Genre,
@@ -84,6 +81,6 @@ class OrderApiTests(TestCase):
         response = self.client.get(f"/api/cinema/movie_sessions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            response.data[0]["tickets_available"],
+            response.data["results"][0]["tickets_available"],
             self.cinema_hall.capacity - 1,
         )

--- a/cinema/urls.py
+++ b/cinema/urls.py
@@ -7,6 +7,7 @@ from cinema.views import (
     CinemaHallViewSet,
     MovieViewSet,
     MovieSessionViewSet,
+    OrderViewSet,
 )
 
 router = routers.DefaultRouter()
@@ -15,6 +16,7 @@ router.register("actors", ActorViewSet)
 router.register("cinema_halls", CinemaHallViewSet)
 router.register("movies", MovieViewSet)
 router.register("movie_sessions", MovieSessionViewSet)
+router.register("orders", OrderViewSet)
 
 urlpatterns = [path("", include(router.urls))]
 

--- a/cinema/views.py
+++ b/cinema/views.py
@@ -92,7 +92,10 @@ class MovieSessionViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(show_time__date=date)
 
         if movie_id:
-            queryset = queryset.filter(movie_id=int(movie_id))
+            try:
+                queryset = queryset.filter(movie_id=int(movie_id))
+            except ValueError:
+                queryset = queryset.none()
 
         if self.action == "list":
             queryset = queryset.annotate(

--- a/cinema/views.py
+++ b/cinema/views.py
@@ -1,7 +1,14 @@
+from django.db.models import Count, F
 from rest_framework import viewsets
 
-from cinema.models import Genre, Actor, CinemaHall, Movie, MovieSession
-
+from cinema.models import (
+    Genre,
+    Actor,
+    CinemaHall,
+    Movie,
+    MovieSession,
+    Order,
+)
 from cinema.serializers import (
     GenreSerializer,
     ActorSerializer,
@@ -12,6 +19,8 @@ from cinema.serializers import (
     MovieDetailSerializer,
     MovieSessionDetailSerializer,
     MovieListSerializer,
+    OrderSerializer,
+    OrderListSerializer,
 )
 
 
@@ -34,13 +43,37 @@ class MovieViewSet(viewsets.ModelViewSet):
     queryset = Movie.objects.all()
     serializer_class = MovieSerializer
 
+    @staticmethod
+    def _params_to_ints(qs):
+        """Converts a list of string IDs to a list of integers"""
+        return [int(str_id) for str_id in qs.split(",")]
+
+    def get_queryset(self):
+        """Retrieve the movies with filters"""
+        title = self.request.query_params.get("title")
+        genres = self.request.query_params.get("genres")
+        actors = self.request.query_params.get("actors")
+
+        queryset = self.queryset
+
+        if title:
+            queryset = queryset.filter(title__icontains=title)
+
+        if genres:
+            genres_ids = self._params_to_ints(genres)
+            queryset = queryset.filter(genres__id__in=genres_ids)
+
+        if actors:
+            actors_ids = self._params_to_ints(actors)
+            queryset = queryset.filter(actors__id__in=actors_ids)
+
+        return queryset.distinct()
+
     def get_serializer_class(self):
         if self.action == "list":
             return MovieListSerializer
-
         if self.action == "retrieve":
             return MovieDetailSerializer
-
         return MovieSerializer
 
 
@@ -48,11 +81,49 @@ class MovieSessionViewSet(viewsets.ModelViewSet):
     queryset = MovieSession.objects.all()
     serializer_class = MovieSessionSerializer
 
+    def get_queryset(self):
+        """Retrieve the movie sessions with filters"""
+        date = self.request.query_params.get("date")
+        movie_id = self.request.query_params.get("movie")
+
+        queryset = self.queryset
+
+        if date:
+            queryset = queryset.filter(show_time__date=date)
+
+        if movie_id:
+            queryset = queryset.filter(movie_id=int(movie_id))
+
+        if self.action == "list":
+            queryset = queryset.annotate(
+                tickets_available=(
+                    F("cinema_hall__rows") * F("cinema_hall__seats_in_row")
+                    - Count("tickets")
+                )
+            )
+
+        return queryset
+
     def get_serializer_class(self):
         if self.action == "list":
             return MovieSessionListSerializer
-
         if self.action == "retrieve":
             return MovieSessionDetailSerializer
-
         return MovieSessionSerializer
+
+
+class OrderViewSet(viewsets.ModelViewSet):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+
+    def get_queryset(self):
+        """Filter orders by authenticated user"""
+        return self.queryset.filter(user=self.request.user)
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return OrderListSerializer
+        return OrderSerializer
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)

--- a/cinema_service/settings.py
+++ b/cinema_service/settings.py
@@ -124,7 +124,7 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_TZ = False
+USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
@@ -136,3 +136,9 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Django REST Framework settings
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",  # noqa: E501
+    "PAGE_SIZE": 10,
+}


### PR DESCRIPTION
Add OrderViewSet and Ticket/Order serializers
Implement filtering for Movies (title, genres, actors)
Implement filtering for MovieSessions (date, movie)
Add taken_places to MovieSession detail endpoint
Add tickets_available to MovieSession list endpoint
Configure pagination in settings (PAGE_SIZE=10)
Update all tests to work with pagination
Update .gitignore to exclude db.sqlite3"